### PR TITLE
[#8] 디자인 시스템 + Home 화면 UI 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# ConJam Project Rules
+
+## Project Overview
+ConJam은 국내 콘서트 정보를 통합하여 보여주는 Android 앱입니다.
+KOPIS(공연예술통합전산망) OpenAPI를 데이터 소스로 사용합니다.
+
+## Git Workflow
+
+### Issue Tracking
+- 모든 작업은 GitHub Issue로 먼저 생성합니다.
+- Issue 제목 형식: `feature : XX 기능 개발` 또는 `fix : XX 버그 수정`
+
+### Branch Naming
+- Issue 번호를 기반으로 브랜치를 생성합니다.
+- 형식: `feature/#<이슈번호>` (예: `feature/#2`)
+
+### Commit Convention
+- 커밋 메시지에 이슈 번호를 포함합니다.
+- 형식: `[#이슈번호] 커밋 메시지` (예: `[#2] Home 화면 UI 구현`)
+
+### PR (Pull Request)
+- 작업 완료 후 PR을 생성하여 사용자가 리뷰 후 반영합니다.
+- PR 대상 브랜치: `develop`
+
+## Tech Stack
+- **Android**: Kotlin, Jetpack Compose, Material3
+- **Architecture**: MVVM, Navigation Compose, StateFlow
+- **Data Source**: KOPIS OpenAPI (공연예술통합전산망)
+- **Backend** (예정): AWS Lambda
+- **Auth** (예정): Google Login
+- **Push** (예정): FCM
+
+## Design System
+- **Theme**: Dark theme 기본
+- **Primary Color**: #7B61FF (보라)
+- **Background**: #121212 (다크 그레이)
+- **Card-based layout**: 포스터 이미지 강조
+
+## Module Structure
+- `app/` - Application entry point
+- `feature/` - 화면별 기능 구현 (home, search, calendar, bookmark, setting)
+- `core/data/` - 데이터 레이어 (추후 구현)
+- `core/network/` - 네트워크 레이어 (추후 구현)
+- `core/model/` - 공유 데이터 모델 (추후 구현)
+
+## File Convention
+각 feature 디렉토리는 다음 파일 구조를 따릅니다:
+- `Route<Feature>.kt` - 네비게이션 라우트
+- `<feature>NavGraph.kt` - 네비게이션 그래프
+- `<Feature>Screen.kt` - UI 화면 (Composable)
+- `<Feature>ViewModel.kt` - 상태 관리
+- `<Feature>State.kt` - 상태 데이터 클래스
+
+## Repositories
+- Android: https://github.com/ConJam-project/ConJam
+- Backend: https://github.com/ConJam-project/ConJam_Backend

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.runtime.android)
     implementation(libs.androidx.navigation.compose)

--- a/feature/src/main/java/com/km/feature/home/Concert.kt
+++ b/feature/src/main/java/com/km/feature/home/Concert.kt
@@ -1,0 +1,28 @@
+package com.km.feature.home
+
+data class Concert(
+    val id: String,
+    val title: String,
+    val startDate: String,
+    val endDate: String,
+    val venue: String,
+    val posterUrl: String = "",
+    val genre: String = "",
+    val state: ConcertState = ConcertState.UPCOMING,
+    val isOpenRun: Boolean = false,
+)
+
+enum class ConcertState(val label: String) {
+    UPCOMING("공연예정"),
+    ONGOING("공연중"),
+    COMPLETED("공연완료"),
+}
+
+enum class Genre(val label: String) {
+    CONCERT("콘서트"),
+    MUSICAL("뮤지컬"),
+    PLAY("연극"),
+    CLASSIC("클래식"),
+    OPERA("오페라"),
+    DANCE("무용"),
+}

--- a/feature/src/main/java/com/km/feature/home/HomeScreen.kt
+++ b/feature/src/main/java/com/km/feature/home/HomeScreen.kt
@@ -1,25 +1,195 @@
 package com.km.feature.home
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.km.feature.ui.component.ConcertCard
+import com.km.feature.ui.component.ConcertSmallCard
+import com.km.feature.ui.component.FeaturedBanner
+import com.km.feature.ui.component.SectionHeader
+import com.km.feature.ui.theme.ConJamTheme
+import com.km.feature.ui.theme.Primary
+import com.km.feature.ui.theme.TextSecondary
 
 @Composable
-fun HomeRoute(padding: PaddingValues) {
-    HomeScreen()
+fun HomeRoute(
+    viewModel: HomeViewModel = viewModel(),
+    padding: PaddingValues,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    HomeScreen(
+        modifier = Modifier
+            .padding(padding)
+            .fillMaxSize(),
+        state = state,
+    )
 }
 
 @Composable
-private fun HomeScreen(modifier: Modifier = Modifier) {
-    Box(
-        modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+private fun HomeScreen(
+    modifier: Modifier = Modifier,
+    state: HomeState,
+) {
+    LazyColumn(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        Text("home")
+        // Top Bar
+        item {
+            HomeTopBar()
+        }
+
+        // Featured Banner
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+            FeaturedBanner(
+                concerts = state.featuredConcerts,
+            )
+        }
+
+        // Ticket Open Soon Section
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+            SectionHeader(
+                title = "티켓 오픈 임박",
+                onMoreClick = { },
+            )
+        }
+
+        item {
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 20.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(state.ticketOpenSoonConcerts, key = { it.id }) { concert ->
+                    ConcertSmallCard(concert = concert)
+                }
+            }
+        }
+
+        // New Concerts Section
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+            SectionHeader(
+                title = "새로 등록된 공연",
+                onMoreClick = { },
+            )
+        }
+
+        items(state.newConcerts, key = { it.id }) { concert ->
+            ConcertCard(
+                concert = concert,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 6.dp),
+            )
+        }
+
+        // Bottom spacing
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun HomeTopBar() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column {
+            Text(
+                text = "ConJam",
+                style = MaterialTheme.typography.headlineMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+                color = Primary,
+            )
+            Text(
+                text = "모든 공연을 한눈에",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+            )
+        }
+
+        IconButton(onClick = { }) {
+            Icon(
+                imageVector = Icons.Outlined.Notifications,
+                contentDescription = "알림",
+                modifier = Modifier.size(26.dp),
+                tint = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Composable
+private fun HomeScreenPreview() {
+    ConJamTheme {
+        HomeScreen(
+            state = HomeState(
+                featuredConcerts = listOf(
+                    Concert(
+                        id = "1",
+                        title = "2025 IU Concert",
+                        startDate = "2025.04.12",
+                        endDate = "2025.04.13",
+                        venue = "KSPO DOME",
+                        genre = "콘서트",
+                    ),
+                ),
+                ticketOpenSoonConcerts = listOf(
+                    Concert(
+                        id = "2",
+                        title = "DAY6 CONCERT",
+                        startDate = "2025.06.21",
+                        endDate = "2025.06.22",
+                        venue = "체조경기장",
+                        genre = "콘서트",
+                    ),
+                ),
+                newConcerts = listOf(
+                    Concert(
+                        id = "3",
+                        title = "뮤지컬 레미제라블",
+                        startDate = "2025.09.01",
+                        endDate = "2025.12.31",
+                        venue = "블루스퀘어",
+                        genre = "뮤지컬",
+                        state = ConcertState.UPCOMING,
+                    ),
+                ),
+            ),
+        )
     }
 }

--- a/feature/src/main/java/com/km/feature/home/HomeState.kt
+++ b/feature/src/main/java/com/km/feature/home/HomeState.kt
@@ -1,0 +1,7 @@
+package com.km.feature.home
+
+data class HomeState(
+    val featuredConcerts: List<Concert> = emptyList(),
+    val ticketOpenSoonConcerts: List<Concert> = emptyList(),
+    val newConcerts: List<Concert> = emptyList(),
+)

--- a/feature/src/main/java/com/km/feature/home/HomeViewModel.kt
+++ b/feature/src/main/java/com/km/feature/home/HomeViewModel.kt
@@ -1,0 +1,155 @@
+package com.km.feature.home
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class HomeViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(HomeState())
+    val state: StateFlow<HomeState> = _state.asStateFlow()
+
+    init {
+        loadDummyData()
+    }
+
+    private fun loadDummyData() {
+        _state.value = HomeState(
+            featuredConcerts = listOf(
+                Concert(
+                    id = "PF001",
+                    title = "2025 IU Concert 'The Winning'",
+                    startDate = "2025.04.12",
+                    endDate = "2025.04.13",
+                    venue = "KSPO DOME",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF002",
+                    title = "SEVENTEEN WORLD TOUR [FOLLOW] AGAIN",
+                    startDate = "2025.05.01",
+                    endDate = "2025.05.04",
+                    venue = "고척스카이돔",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF003",
+                    title = "뮤지컬 <오페라의 유령>",
+                    startDate = "2025.03.01",
+                    endDate = "2025.06.30",
+                    venue = "블루스퀘어 신한카드홀",
+                    genre = "뮤지컬",
+                    state = ConcertState.ONGOING,
+                    isOpenRun = true,
+                ),
+            ),
+            ticketOpenSoonConcerts = listOf(
+                Concert(
+                    id = "PF004",
+                    title = "DAY6 CONCERT <FOREVER YOUNG>",
+                    startDate = "2025.06.21",
+                    endDate = "2025.06.22",
+                    venue = "올림픽공원 체조경기장",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF005",
+                    title = "aespa LIVE TOUR - SYNK : PARALLEL LINE",
+                    startDate = "2025.07.05",
+                    endDate = "2025.07.06",
+                    venue = "KSPO DOME",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF006",
+                    title = "뮤지컬 <시카고>",
+                    startDate = "2025.05.10",
+                    endDate = "2025.08.03",
+                    venue = "디큐브 링크아트센터",
+                    genre = "뮤지컬",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF007",
+                    title = "2025 성시경 연말 콘서트",
+                    startDate = "2025.12.24",
+                    endDate = "2025.12.25",
+                    venue = "세종문화회관 대극장",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF008",
+                    title = "국립발레단 <백조의 호수>",
+                    startDate = "2025.05.16",
+                    endDate = "2025.05.18",
+                    venue = "예술의전당 오페라극장",
+                    genre = "무용",
+                    state = ConcertState.UPCOMING,
+                ),
+            ),
+            newConcerts = listOf(
+                Concert(
+                    id = "PF009",
+                    title = "2025 박효신 콘서트 <LOVERS>",
+                    startDate = "2025.08.15",
+                    endDate = "2025.08.17",
+                    venue = "KSPO DOME",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF010",
+                    title = "뮤지컬 <레미제라블>",
+                    startDate = "2025.09.01",
+                    endDate = "2025.12.31",
+                    venue = "블루스퀘어 신한카드홀",
+                    genre = "뮤지컬",
+                    state = ConcertState.UPCOMING,
+                    isOpenRun = true,
+                ),
+                Concert(
+                    id = "PF011",
+                    title = "서울시향 베토벤 교향곡 전곡 시리즈",
+                    startDate = "2025.10.01",
+                    endDate = "2025.10.05",
+                    venue = "롯데콘서트홀",
+                    genre = "클래식",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF012",
+                    title = "연극 <햄릿> - 국립극단",
+                    startDate = "2025.06.01",
+                    endDate = "2025.06.30",
+                    venue = "명동예술극장",
+                    genre = "연극",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF013",
+                    title = "BLACKPINK WORLD TOUR [BORN PINK] FINALE",
+                    startDate = "2025.11.08",
+                    endDate = "2025.11.09",
+                    venue = "고척스카이돔",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+                Concert(
+                    id = "PF014",
+                    title = "뮤지컬 <위키드>",
+                    startDate = "2025.07.01",
+                    endDate = "2025.10.31",
+                    venue = "충무아트센터 대극장",
+                    genre = "뮤지컬",
+                    state = ConcertState.UPCOMING,
+                ),
+            ),
+        )
+    }
+}

--- a/feature/src/main/java/com/km/feature/main/MainBottomBar.kt
+++ b/feature/src/main/java/com/km/feature/main/MainBottomBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -22,9 +23,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.km.feature.ui.theme.ConJamTheme
+import com.km.feature.ui.theme.Primary
+import com.km.feature.ui.theme.SurfaceDark
+import com.km.feature.ui.theme.TextSecondary
+import com.km.feature.ui.theme.TextTertiary
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
@@ -41,7 +47,8 @@ fun MainBottomBar(
             modifier = modifier
                 .fillMaxWidth()
                 .height(56.dp)
-                .background(color = Color.White),
+                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                .background(color = SurfaceDark),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             tabs.forEach { tab ->
@@ -76,23 +83,19 @@ private fun RowScope.MainBottomBarItem(
         contentAlignment = Alignment.Center,
     ) {
         Column(
-            horizontalAlignment =Alignment.CenterHorizontally,
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(
                 imageVector = tab.icon,
                 contentDescription = tab.contentDescription,
-                tint = if (selected) {
-                    Color.Blue
-                } else {
-                    MaterialTheme.colorScheme.outline
-                },
-                modifier = Modifier.size(34.dp),
+                tint = if (selected) Primary else TextTertiary,
+                modifier = Modifier.size(24.dp),
             )
 
-            Spacer(Modifier.height(6.dp))
+            Spacer(Modifier.height(4.dp))
             Text(
                 style = MaterialTheme.typography.labelSmall.copy(
-                    color = if (selected) Color.Black else Color.Gray
+                    color = if (selected) Primary else TextSecondary,
                 ),
                 text = tab.title,
             )
@@ -101,12 +104,14 @@ private fun RowScope.MainBottomBarItem(
 }
 
 @Composable
-@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun MainBottomBarPreview() {
-    MainBottomBar(
-        visible = true,
-        tabs = MainTab.entries.toPersistentList(),
-        currentTab = MainTab.HOME,
-        onTabSelected = { },
-    )
+    ConJamTheme {
+        MainBottomBar(
+            visible = true,
+            tabs = MainTab.entries.toPersistentList(),
+            currentTab = MainTab.HOME,
+            onTabSelected = { },
+        )
+    }
 }

--- a/feature/src/main/java/com/km/feature/main/MainNavHost.kt
+++ b/feature/src/main/java/com/km/feature/main/MainNavHost.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.NavHost
 import com.km.feature.bookmark.bookmarkNavGraph
 import com.km.feature.calendar.calendarNavGraph
@@ -23,7 +23,7 @@ fun MainNavHost(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(MaterialTheme.colorScheme.background)
     ) {
         NavHost(
             navController = navigator.navController,

--- a/feature/src/main/java/com/km/feature/ui/component/ConcertCard.kt
+++ b/feature/src/main/java/com/km/feature/ui/component/ConcertCard.kt
@@ -1,0 +1,135 @@
+package com.km.feature.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.km.feature.home.Concert
+import com.km.feature.home.ConcertState
+import com.km.feature.ui.theme.CardDark
+import com.km.feature.ui.theme.ConJamTheme
+import com.km.feature.ui.theme.Primary
+import com.km.feature.ui.theme.TextSecondary
+
+@Composable
+fun ConcertCard(
+    concert: Concert,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(CardDark)
+            .clickable(onClick = onClick)
+            .padding(12.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        // Poster placeholder
+        Box(
+            modifier = Modifier
+                .size(width = 80.dp, height = 110.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(Primary.copy(alpha = 0.15f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = concert.genre.take(2),
+                style = MaterialTheme.typography.titleMedium,
+                color = Primary,
+            )
+        }
+
+        Spacer(modifier = Modifier.width(14.dp))
+
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = concert.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Text(
+                text = "${concert.startDate} ~ ${concert.endDate}",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.LocationOn,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = TextSecondary,
+                )
+                Spacer(modifier = Modifier.width(2.dp))
+                Text(
+                    text = concert.venue,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                GenreBadge(genre = concert.genre)
+                Spacer(modifier = Modifier.width(6.dp))
+                ConcertStateBadge(state = concert.state)
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Composable
+private fun ConcertCardPreview() {
+    ConJamTheme {
+        ConcertCard(
+            concert = Concert(
+                id = "1",
+                title = "2025 IU Concert 'The Winning'",
+                startDate = "2025.04.12",
+                endDate = "2025.04.13",
+                venue = "KSPO DOME",
+                genre = "콘서트",
+                state = ConcertState.UPCOMING,
+            ),
+        )
+    }
+}

--- a/feature/src/main/java/com/km/feature/ui/component/ConcertSmallCard.kt
+++ b/feature/src/main/java/com/km/feature/ui/component/ConcertSmallCard.kt
@@ -1,0 +1,107 @@
+package com.km.feature.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.km.feature.home.Concert
+import com.km.feature.home.ConcertState
+import com.km.feature.ui.theme.CardDark
+import com.km.feature.ui.theme.ConJamTheme
+import com.km.feature.ui.theme.Primary
+import com.km.feature.ui.theme.TextSecondary
+
+@Composable
+fun ConcertSmallCard(
+    concert: Concert,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) {
+    Column(
+        modifier = modifier
+            .width(140.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(CardDark)
+            .clickable(onClick = onClick)
+            .padding(bottom = 10.dp),
+    ) {
+        // Poster placeholder
+        Box(
+            modifier = Modifier
+                .size(width = 140.dp, height = 180.dp)
+                .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                .background(Primary.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = concert.genre.take(2),
+                style = MaterialTheme.typography.headlineSmall,
+                color = Primary.copy(alpha = 0.6f),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = concert.title,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(horizontal = 10.dp),
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = concert.startDate,
+            style = MaterialTheme.typography.labelSmall,
+            color = TextSecondary,
+            modifier = Modifier.padding(horizontal = 10.dp),
+        )
+
+        Spacer(modifier = Modifier.height(2.dp))
+
+        Text(
+            text = concert.venue,
+            style = MaterialTheme.typography.labelSmall,
+            color = TextSecondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(horizontal = 10.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Composable
+private fun ConcertSmallCardPreview() {
+    ConJamTheme {
+        ConcertSmallCard(
+            concert = Concert(
+                id = "1",
+                title = "DAY6 CONCERT <FOREVER YOUNG>",
+                startDate = "2025.06.21",
+                endDate = "2025.06.22",
+                venue = "올림픽공원 체조경기장",
+                genre = "콘서트",
+                state = ConcertState.UPCOMING,
+            ),
+        )
+    }
+}

--- a/feature/src/main/java/com/km/feature/ui/component/ConcertStateBadge.kt
+++ b/feature/src/main/java/com/km/feature/ui/component/ConcertStateBadge.kt
@@ -1,0 +1,55 @@
+package com.km.feature.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.km.feature.home.ConcertState
+import com.km.feature.ui.theme.StateCompleted
+import com.km.feature.ui.theme.StateOngoing
+import com.km.feature.ui.theme.StateUpcoming
+
+@Composable
+fun ConcertStateBadge(
+    state: ConcertState,
+    modifier: Modifier = Modifier,
+) {
+    val color = when (state) {
+        ConcertState.UPCOMING -> StateUpcoming
+        ConcertState.ONGOING -> StateOngoing
+        ConcertState.COMPLETED -> StateCompleted
+    }
+
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(color.copy(alpha = 0.1f))
+            .padding(horizontal = 8.dp, vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = state.label,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+        )
+    }
+}

--- a/feature/src/main/java/com/km/feature/ui/component/FeaturedBanner.kt
+++ b/feature/src/main/java/com/km/feature/ui/component/FeaturedBanner.kt
@@ -1,0 +1,139 @@
+package com.km.feature.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.km.feature.home.Concert
+import com.km.feature.home.ConcertState
+import com.km.feature.ui.theme.ConJamTheme
+import com.km.feature.ui.theme.Primary
+import com.km.feature.ui.theme.TextSecondary
+
+@Composable
+fun FeaturedBanner(
+    concerts: List<Concert>,
+    modifier: Modifier = Modifier,
+    onConcertClick: (Concert) -> Unit = {},
+) {
+    if (concerts.isEmpty()) return
+
+    val pagerState = rememberPagerState(pageCount = { concerts.size })
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp),
+        ) { page ->
+            val concert = concerts[page]
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 4.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(Primary.copy(alpha = 0.12f))
+                    .clickable { onConcertClick(concert) },
+            ) {
+                // Content overlay at bottom
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .fillMaxWidth()
+                        .background(
+                            brush = androidx.compose.ui.graphics.Brush.verticalGradient(
+                                colors = listOf(
+                                    androidx.compose.ui.graphics.Color.Transparent,
+                                    androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.8f),
+                                ),
+                            ),
+                        )
+                        .padding(16.dp),
+                ) {
+                    GenreBadge(genre = concert.genre)
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = concert.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "${concert.startDate} | ${concert.venue}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextSecondary,
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        // Page indicators
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            repeat(concerts.size) { index ->
+                Box(
+                    modifier = Modifier
+                        .padding(horizontal = 3.dp)
+                        .size(if (pagerState.currentPage == index) 8.dp else 6.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (pagerState.currentPage == index) Primary
+                            else Primary.copy(alpha = 0.3f),
+                        ),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Composable
+private fun FeaturedBannerPreview() {
+    ConJamTheme {
+        FeaturedBanner(
+            concerts = listOf(
+                Concert(
+                    id = "1",
+                    title = "2025 IU Concert 'The Winning'",
+                    startDate = "2025.04.12",
+                    endDate = "2025.04.13",
+                    venue = "KSPO DOME",
+                    genre = "콘서트",
+                    state = ConcertState.UPCOMING,
+                ),
+            ),
+        )
+    }
+}

--- a/feature/src/main/java/com/km/feature/ui/component/GenreBadge.kt
+++ b/feature/src/main/java/com/km/feature/ui/component/GenreBadge.kt
@@ -1,0 +1,52 @@
+package com.km.feature.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.km.feature.ui.theme.GenreClassic
+import com.km.feature.ui.theme.GenreConcert
+import com.km.feature.ui.theme.GenreDance
+import com.km.feature.ui.theme.GenreMusical
+import com.km.feature.ui.theme.GenreOpera
+import com.km.feature.ui.theme.GenrePlay
+
+@Composable
+fun GenreBadge(
+    genre: String,
+    modifier: Modifier = Modifier,
+) {
+    val color = genreColor(genre)
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 8.dp, vertical = 3.dp),
+    ) {
+        Text(
+            text = genre,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+        )
+    }
+}
+
+private fun genreColor(genre: String): Color {
+    return when {
+        genre.contains("콘서트") -> GenreConcert
+        genre.contains("뮤지컬") -> GenreMusical
+        genre.contains("연극") -> GenrePlay
+        genre.contains("클래식") -> GenreClassic
+        genre.contains("오페라") -> GenreOpera
+        genre.contains("무용") -> GenreDance
+        else -> GenreConcert
+    }
+}

--- a/feature/src/main/java/com/km/feature/ui/component/SectionHeader.kt
+++ b/feature/src/main/java/com/km/feature/ui/component/SectionHeader.kt
@@ -1,0 +1,43 @@
+package com.km.feature.ui.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.km.feature.ui.theme.TextSecondary
+
+@Composable
+fun SectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    onMoreClick: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        if (onMoreClick != null) {
+            Text(
+                text = "더보기",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+                modifier = Modifier.clickable(onClick = onMoreClick),
+            )
+        }
+    }
+}

--- a/feature/src/main/java/com/km/feature/ui/theme/Color.kt
+++ b/feature/src/main/java/com/km/feature/ui/theme/Color.kt
@@ -2,10 +2,45 @@ package com.km.feature.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+// Primary
+val Primary = Color(0xFF7B61FF)
+val PrimaryLight = Color(0xFFA78BFA)
+val PrimaryDark = Color(0xFF5B3FD9)
+
+// Background & Surface
+val BackgroundDark = Color(0xFF121212)
+val SurfaceDark = Color(0xFF1E1E1E)
+val SurfaceVariantDark = Color(0xFF2A2A2A)
+val CardDark = Color(0xFF252525)
+
+// Text
+val TextPrimary = Color(0xFFFFFFFF)
+val TextSecondary = Color(0xFFB3B3B3)
+val TextTertiary = Color(0xFF757575)
+
+// Accent
+val AccentRed = Color(0xFFFF6B6B)
+val AccentGreen = Color(0xFF4CAF50)
+val AccentOrange = Color(0xFFFF9800)
+val AccentBlue = Color(0xFF42A5F5)
+
+// Genre colors
+val GenreConcert = Color(0xFFFF6B6B)
+val GenreMusical = Color(0xFFFFD93D)
+val GenrePlay = Color(0xFF6BCB77)
+val GenreClassic = Color(0xFF4D96FF)
+val GenreOpera = Color(0xFFFF6BD6)
+val GenreDance = Color(0xFFFF9F45)
+
+// State colors
+val StateUpcoming = Color(0xFF42A5F5)
+val StateOngoing = Color(0xFF4CAF50)
+val StateCompleted = Color(0xFF757575)
+
+// Legacy (keep for compatibility)
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)
-
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)

--- a/feature/src/main/java/com/km/feature/ui/theme/Theme.kt
+++ b/feature/src/main/java/com/km/feature/ui/theme/Theme.kt
@@ -1,58 +1,33 @@
 package com.km.feature.ui.theme
 
-import android.app.Activity
-import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+private val ConJamColorScheme = darkColorScheme(
+    primary = Primary,
+    onPrimary = TextPrimary,
+    primaryContainer = PrimaryDark,
+    onPrimaryContainer = TextPrimary,
+    secondary = PrimaryLight,
+    onSecondary = BackgroundDark,
+    background = BackgroundDark,
+    onBackground = TextPrimary,
+    surface = SurfaceDark,
+    onSurface = TextPrimary,
+    surfaceVariant = SurfaceVariantDark,
+    onSurfaceVariant = TextSecondary,
+    outline = TextTertiary,
+    error = AccentRed,
 )
 
 @Composable
 fun ConJamTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
-
     MaterialTheme(
-        colorScheme = colorScheme,
+        colorScheme = ConJamColorScheme,
         typography = Typography,
-        content = content
+        content = content,
     )
 }

--- a/feature/src/main/java/com/km/feature/ui/theme/Type.kt
+++ b/feature/src/main/java/com/km/feature/ui/theme/Type.kt
@@ -6,29 +6,77 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
 val Typography = Typography(
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 20.sp,
+        lineHeight = 28.sp,
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 18.sp,
+        lineHeight = 26.sp,
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+    ),
+    titleSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    ),
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
+    ),
+    bodyMedium = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
     ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
-    )
-    */
+        fontSize = 10.sp,
+        lineHeight = 14.sp,
+    ),
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-runtime-android = { group = "androidx.navigation", name = "navigation-runtime-android", version.ref = "navigationRuntimeAndroid" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }


### PR DESCRIPTION
## Summary
- 다크 테마 기반 디자인 시스템 정의 (Color, Theme, Typography)
- KOPIS 기반 Concert 데이터 모델 확장 (장르, 공연상태, 포스터URL 등)
- Home 화면 전체 재구현 (Featured 배너, 티켓오픈임박 섹션, 새 공연 리스트)
- 재사용 가능한 공통 컴포넌트 6개 생성
- BottomBar, NavHost 다크 테마 적용

## Test plan
- [x] Android Studio에서 HomeScreen Preview 확인
- [ ] 앱 빌드 후 Home 탭 UI 확인
- [ ] 배너 좌우 스와이프 동작 확인
- [ ] 티켓오픈임박 가로 스크롤 확인
- [ ] 새 공연 리스트 세로 스크롤 확인
- [ ] 다크 테마 전체 적용 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)