### PR TITLE
Feature : #10 Calendar 화면 개발

### DIFF
--- a/feature/src/main/java/com/km/feature/calendar/CalendarScreen.kt
+++ b/feature/src/main/java/com/km/feature/calendar/CalendarScreen.kt
@@ -1,28 +1,416 @@
 package com.km.feature.calendar
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.km.feature.home.Concert
+import com.km.feature.ui.component.GenreBadge
+import com.km.feature.ui.theme.AccentOrange
+import com.km.feature.ui.theme.CardDark
+import com.km.feature.ui.theme.ConJamTheme
+import com.km.feature.ui.theme.Primary
+import com.km.feature.ui.theme.SurfaceVariantDark
+import com.km.feature.ui.theme.TextSecondary
+import com.km.feature.ui.theme.TextTertiary
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
-fun CalendarRoute(padding: PaddingValues) {
-    CalendarScreen(padding = padding)
+fun CalendarRoute(
+    padding: PaddingValues,
+    viewModel: CalendarViewModel = viewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    CalendarScreen(
+        modifier = Modifier
+            .padding(padding)
+            .fillMaxSize(),
+        state = state,
+        onPreviousMonth = viewModel::onPreviousMonth,
+        onNextMonth = viewModel::onNextMonth,
+        onDateSelect = viewModel::onDateSelect,
+    )
 }
 
 @Composable
 private fun CalendarScreen(
-    padding: PaddingValues,
+    modifier: Modifier = Modifier,
+    state: CalendarState,
+    onPreviousMonth: () -> Unit = {},
+    onNextMonth: () -> Unit = {},
+    onDateSelect: (LocalDate) -> Unit = {},
+) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        // Month Navigation
+        MonthHeader(
+            yearMonth = state.currentMonth,
+            onPrevious = onPreviousMonth,
+            onNext = onNextMonth,
+        )
+
+        // Day of Week Header
+        DayOfWeekHeader()
+
+        // Calendar Grid
+        CalendarGrid(
+            yearMonth = state.currentMonth,
+            selectedDate = state.selectedDate,
+            concertDates = state.concertEvents.keys,
+            ticketOpenDates = state.ticketOpenEvents.keys,
+            onDateSelect = onDateSelect,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Selected Date Events
+        SelectedDateEvents(
+            selectedDate = state.selectedDate,
+            concerts = state.concertEvents[state.selectedDate].orEmpty(),
+            ticketOpens = state.ticketOpenEvents[state.selectedDate].orEmpty(),
+        )
+    }
+}
+
+@Composable
+private fun MonthHeader(
+    yearMonth: YearMonth,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onPrevious) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = "이전 달",
+                tint = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+
+        Text(
+            text = "${yearMonth.year}년 ${yearMonth.monthValue}월",
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+
+        IconButton(onClick = onNext) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "다음 달",
+                tint = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DayOfWeekHeader() {
+    val daysOfWeek = listOf(
+        DayOfWeek.SUNDAY, DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+        DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY, DayOfWeek.SATURDAY,
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 4.dp),
+    ) {
+        daysOfWeek.forEach { day ->
+            Text(
+                text = day.getDisplayName(TextStyle.SHORT, Locale.KOREAN),
+                style = MaterialTheme.typography.labelMedium,
+                color = when (day) {
+                    DayOfWeek.SUNDAY -> Primary.copy(alpha = 0.7f)
+                    DayOfWeek.SATURDAY -> Primary.copy(alpha = 0.5f)
+                    else -> TextTertiary
+                },
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CalendarGrid(
+    yearMonth: YearMonth,
+    selectedDate: LocalDate,
+    concertDates: Set<LocalDate>,
+    ticketOpenDates: Set<LocalDate>,
+    onDateSelect: (LocalDate) -> Unit,
+) {
+    val firstDayOfMonth = yearMonth.atDay(1)
+    val daysInMonth = yearMonth.lengthOfMonth()
+    val startDayOfWeek = firstDayOfMonth.dayOfWeek.value % 7 // Sunday = 0
+
+    val totalCells = startDayOfWeek + daysInMonth
+    val rows = (totalCells + 6) / 7
+
+    Column(
+        modifier = Modifier.padding(horizontal = 20.dp),
+    ) {
+        for (row in 0 until rows) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                for (col in 0..6) {
+                    val cellIndex = row * 7 + col
+                    val dayNumber = cellIndex - startDayOfWeek + 1
+
+                    if (dayNumber in 1..daysInMonth) {
+                        val date = yearMonth.atDay(dayNumber)
+                        val isSelected = date == selectedDate
+                        val isToday = date == LocalDate.now()
+                        val hasConcert = date in concertDates
+                        val hasTicketOpen = date in ticketOpenDates
+
+                        CalendarDayCell(
+                            day = dayNumber,
+                            isSelected = isSelected,
+                            isToday = isToday,
+                            hasConcert = hasConcert,
+                            hasTicketOpen = hasTicketOpen,
+                            onClick = { onDateSelect(date) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    } else {
+                        Box(modifier = Modifier.weight(1f).aspectRatio(1f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CalendarDayCell(
+    day: Int,
+    isSelected: Boolean,
+    isToday: Boolean,
+    hasConcert: Boolean,
+    hasTicketOpen: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+        modifier = modifier
+            .aspectRatio(1f)
+            .padding(2.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .then(
+                when {
+                    isSelected -> Modifier.background(Primary)
+                    isToday -> Modifier.background(SurfaceVariantDark)
+                    else -> Modifier
+                }
+            )
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
     ) {
-        Text("calendar")
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = day.toString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = when {
+                    isSelected -> MaterialTheme.colorScheme.onPrimary
+                    else -> MaterialTheme.colorScheme.onBackground
+                },
+            )
+            // Dots for events
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                if (hasConcert) {
+                    Box(
+                        modifier = Modifier
+                            .size(4.dp)
+                            .clip(CircleShape)
+                            .background(if (isSelected) MaterialTheme.colorScheme.onPrimary else Primary),
+                    )
+                }
+                if (hasTicketOpen) {
+                    Box(
+                        modifier = Modifier
+                            .size(4.dp)
+                            .clip(CircleShape)
+                            .background(if (isSelected) MaterialTheme.colorScheme.onPrimary else AccentOrange),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectedDateEvents(
+    selectedDate: LocalDate,
+    concerts: List<Concert>,
+    ticketOpens: List<Concert>,
+) {
+    val dayOfWeek = selectedDate.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREAN)
+    val dateText = "${selectedDate.monthValue}월 ${selectedDate.dayOfMonth}일 ($dayOfWeek)"
+
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 20.dp),
+    ) {
+        item {
+            Text(
+                text = dateText,
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        }
+
+        if (ticketOpens.isNotEmpty()) {
+            item {
+                Text(
+                    text = "티켓 오픈",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = AccentOrange,
+                    modifier = Modifier.padding(vertical = 6.dp),
+                )
+            }
+            items(ticketOpens, key = { "ticket_${it.id}" }) { concert ->
+                CalendarEventItem(concert = concert, isTicketOpen = true)
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+
+        if (concerts.isNotEmpty()) {
+            item {
+                Text(
+                    text = "공연 일정",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = Primary,
+                    modifier = Modifier.padding(vertical = 6.dp),
+                )
+            }
+            items(concerts, key = { "concert_${it.id}" }) { concert ->
+                CalendarEventItem(concert = concert, isTicketOpen = false)
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+
+        if (concerts.isEmpty() && ticketOpens.isEmpty()) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "이 날짜에 등록된 일정이 없습니다",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = TextTertiary,
+                    )
+                }
+            }
+        }
+
+        item { Spacer(modifier = Modifier.height(16.dp)) }
+    }
+}
+
+@Composable
+private fun CalendarEventItem(
+    concert: Concert,
+    isTicketOpen: Boolean,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(CardDark)
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Color indicator
+        Box(
+            modifier = Modifier
+                .size(width = 3.dp, height = 40.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(if (isTicketOpen) AccentOrange else Primary),
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 12.dp),
+        ) {
+            Text(
+                text = concert.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = if (isTicketOpen) "티켓 오픈" else concert.venue,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+            )
+        }
+
+        GenreBadge(genre = concert.genre)
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Composable
+private fun CalendarScreenPreview() {
+    ConJamTheme {
+        CalendarScreen(state = CalendarState())
     }
 }

--- a/feature/src/main/java/com/km/feature/calendar/CalendarState.kt
+++ b/feature/src/main/java/com/km/feature/calendar/CalendarState.kt
@@ -1,0 +1,12 @@
+package com.km.feature.calendar
+
+import com.km.feature.home.Concert
+import java.time.LocalDate
+import java.time.YearMonth
+
+data class CalendarState(
+    val currentMonth: YearMonth = YearMonth.now(),
+    val selectedDate: LocalDate = LocalDate.now(),
+    val concertEvents: Map<LocalDate, List<Concert>> = emptyMap(),
+    val ticketOpenEvents: Map<LocalDate, List<Concert>> = emptyMap(),
+)

--- a/feature/src/main/java/com/km/feature/calendar/CalendarViewModel.kt
+++ b/feature/src/main/java/com/km/feature/calendar/CalendarViewModel.kt
@@ -1,0 +1,78 @@
+package com.km.feature.calendar
+
+import androidx.lifecycle.ViewModel
+import com.km.feature.home.Concert
+import com.km.feature.home.ConcertState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.time.LocalDate
+import java.time.YearMonth
+
+class CalendarViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(CalendarState())
+    val state: StateFlow<CalendarState> = _state.asStateFlow()
+
+    init {
+        loadDummyData()
+    }
+
+    fun onMonthChange(yearMonth: YearMonth) {
+        _state.update { it.copy(currentMonth = yearMonth) }
+    }
+
+    fun onPreviousMonth() {
+        _state.update { it.copy(currentMonth = it.currentMonth.minusMonths(1)) }
+    }
+
+    fun onNextMonth() {
+        _state.update { it.copy(currentMonth = it.currentMonth.plusMonths(1)) }
+    }
+
+    fun onDateSelect(date: LocalDate) {
+        _state.update { it.copy(selectedDate = date) }
+    }
+
+    private fun loadDummyData() {
+        val now = LocalDate.now()
+        val thisMonth = now.withDayOfMonth(1)
+
+        val concertEvents = mapOf(
+            thisMonth.plusDays(4) to listOf(
+                Concert("PF001", "2025 IU Concert 'The Winning'", "2025.04.12", "2025.04.13", "KSPO DOME", genre = "콘서트", state = ConcertState.UPCOMING),
+            ),
+            thisMonth.plusDays(9) to listOf(
+                Concert("PF003", "뮤지컬 <오페라의 유령>", "2025.03.01", "2025.06.30", "블루스퀘어 신한카드홀", genre = "뮤지컬", state = ConcertState.ONGOING),
+            ),
+            thisMonth.plusDays(14) to listOf(
+                Concert("PF004", "DAY6 CONCERT <FOREVER YOUNG>", "2025.06.21", "2025.06.22", "올림픽공원 체조경기장", genre = "콘서트", state = ConcertState.UPCOMING),
+                Concert("PF012", "연극 <햄릿> - 국립극단", "2025.06.01", "2025.06.30", "명동예술극장", genre = "연극", state = ConcertState.UPCOMING),
+            ),
+            thisMonth.plusDays(20) to listOf(
+                Concert("PF005", "aespa LIVE TOUR - SYNK", "2025.07.05", "2025.07.06", "KSPO DOME", genre = "콘서트", state = ConcertState.UPCOMING),
+            ),
+            thisMonth.plusDays(24) to listOf(
+                Concert("PF011", "서울시향 베토벤 교향곡 전곡 시리즈", "2025.10.01", "2025.10.05", "롯데콘서트홀", genre = "클래식", state = ConcertState.UPCOMING),
+            ),
+        )
+
+        val ticketOpenEvents = mapOf(
+            thisMonth.plusDays(2) to listOf(
+                Concert("PF009", "2025 박효신 콘서트 <LOVERS>", "2025.08.15", "2025.08.17", "KSPO DOME", genre = "콘서트", state = ConcertState.UPCOMING),
+            ),
+            thisMonth.plusDays(7) to listOf(
+                Concert("PF013", "BLACKPINK WORLD TOUR [BORN PINK]", "2025.11.08", "2025.11.09", "고척스카이돔", genre = "콘서트", state = ConcertState.UPCOMING),
+            ),
+            thisMonth.plusDays(14) to listOf(
+                Concert("PF010", "뮤지컬 <레미제라블>", "2025.09.01", "2025.12.31", "블루스퀘어 신한카드홀", genre = "뮤지컬", state = ConcertState.UPCOMING),
+            ),
+        )
+
+        _state.value = CalendarState(
+            concertEvents = concertEvents,
+            ticketOpenEvents = ticketOpenEvents,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- 월간 캘린더 그리드 커스텀 구현 (외부 라이브러리 미사용)
- 월 네비게이션 (이전/다음 달 전환)
- 공연 날짜에 보라색 도트, 티켓 오픈일에 주황색 도트 표시
- 날짜 선택 시 해당 날짜의 공연/티켓 오픈 일정 리스트 표시
- CalendarState, CalendarViewModel 더미 데이터로 구현

## Test plan
- [ ] Calendar 탭에서 월간 캘린더 렌더링 확인
- [ ] 이전/다음 달 네비게이션 동작 확인
- [ ] 공연 날짜 도트(보라) / 티켓오픈 도트(주황) 표시 확인
- [ ] 날짜 선택 시 하단 일정 리스트 변경 확인
- [ ] 일정 없는 날짜 선택 시 빈 상태 메시지 확인

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)